### PR TITLE
add: タイトルバーカラー指定機能の追加

### DIFF
--- a/KyukurarinForm/Forms.cs
+++ b/KyukurarinForm/Forms.cs
@@ -14,10 +14,14 @@ namespace KyukurarinForm
    
     public partial class Forms : Form
     {
-        
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hWnd, int attr, ref int pvAttribute, int cbAttribute);
+
         public Forms(List<Movement> move,Bitmap map,Arial.Position position= Arial.Position.Center,int x=0,int y=0,bool topmost=false)
         {
             InitializeComponent();
+            int titleBarColor = ColorTranslator.ToWin32(Color.FromArgb(254, 201, 215));
+            DwmSetWindowAttribute(Handle, 35, ref titleBarColor, sizeof(int));
             Show();
             TopMost = topmost;
             pos = position;


### PR DESCRIPTION
**コミットメッセージでは、Win10以降と記載しましたが
正しくはWin11のみで正常に動作します。大変申し訳ございませんでした。**

## 変更内容
"DwnSetWindowAttribute"メソッドをインポートし、
ウィンドウのタイトルバーの色をきゅうくらりんの背景色に設定する処理を追加しました。 

## 動作確認済み環境
・Windows 11 (OSビルド 26100.3323)

## 注意点
・先頭にも書かせていただいた通り、Windows10以降ではなく、Windows11のみで正常に動作致します。
・今までプルリクエストを送った経験がないため、もし不備や至らない点があればご指摘いただけると幸いです。
　お手数をおかけしますが何卒よろしくお願いいたします。